### PR TITLE
fix: relocatable installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,14 @@ jobs:
       - run: tree install
       - run: meson test
         working-directory: build
+      - name: test installation
+        run: install/bin/stringspinner --num-events 1
+      - name: test relocatability
+        run: |
+          mkdir relocated
+          cp -r install relocated/
+          relocated/install/bin/stringspinner --num-events 1
+      - name: test symlinking
+        run: |
+          ln -sv install/bin/stringspinner
+          ./stringspinner --num-events 1

--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,11 @@
 project(
   'clas-stringspinner',
   'cpp',
-  meson_version: '>=1.2',
+  meson_version: '>=1.3',
   default_options: {
-    'cpp_std':   'c++17',
-    'buildtype': 'release',
-    'libdir':    'lib',
+    'cpp_std':    'c++17',
+    'buildtype':  'release',
+    'libdir':     'lib',
   },
   version: '0.1.0',
 )
@@ -18,9 +18,11 @@ fmt_dep           = dependency('fmt', method: 'pkg-config', version: '>= 9.1.0')
 stringspinner_dep = dependency('stringspinner', fallback: ['stringspinner', 'stringspinner_dep'])
 
 # config files
+fs = import('fs')
 etc_dir = get_option('sysconfdir') / meson.project_name()
 add_project_arguments(
-  '-DSTRINGSPINNER_ETC="' + get_option('prefix') / etc_dir + '"', # FIXME: makes the installation non-relocatable
+  '-DSTRINGSPINNER_ETCDIR="' + fs.relative_to(etc_dir, get_option('bindir')) + '"',
+  '-DSTRINGSPINNER_PREFIX_ETCDIR="' + get_option('prefix') / etc_dir + '"',
   language: ['cpp'],
 )
 install_subdir(


### PR DESCRIPTION
Make the installation relocatable by encoding relative paths rather than absolute paths. Fallback to absolute path, if relative path fails (which may happen if someone symlinks `stringspinner`)