### PR TITLE
fix: include `fmt/ranges.h`

### DIFF
--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -2,6 +2,7 @@
 #include <array>
 #include <functional>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <fmt/os.h>
 #include <stringspinner/StringSpinner.h>
 


### PR DESCRIPTION
Newer versions of `fmt` require inclusion of `ranges.h` to use `fmt::join`.