### PR TITLE
fix: set symmetric fragmentation function parameters `a` and `b`

### DIFF
--- a/src/config/clas12.h
+++ b/src/config/clas12.h
@@ -70,4 +70,8 @@ static void config_clas12(Pythia8::Pythia& pyth) {
                                                                // TODO: why do we get NO events if this is `on`?
   set_config(pyth, "BeamRemnants:primordialKTremnant = 0.64"); // The width sigma_remn, assigned as a primordial kT to beam-remnant partons. (analogous to PARJ(99))
                                                                // NOTE: this is ignored when `primordialKT == off`
+  //// fragmentation parameters a and b of (1/z) * (1-z)^a * exp(-b m_T^2 / z)
+  set_config(pyth, "StringZ:aLund = 1.2");
+  set_config(pyth, "StringZ:bLund = 0.58");
+
 }


### PR DESCRIPTION
to be consistent with [`clasdis`'s settings](https://github.com/JeffersonLab/clasdis/blob/6f2a40feac88d6726a37b75c05951ab808a74773/clasDIS.F#L272-L274)