### PR TITLE
feat: add option to set any Pythia parameter value

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
     'buildtype':  'release',
     'libdir':     'lib',
   },
-  version: '0.1.3',
+  version: '0.1.4',
 )
 
 # subprojects


### PR DESCRIPTION
Adds the option `--set` to allow users to set _any_ Pythia parameter. This allows us to avoid having to go through the full OSG deployment procedure if we just want to modify one parameter.