### PR TITLE
fix: config function `static` -> `inline`

### DIFF
--- a/src/config/clas12.h
+++ b/src/config/clas12.h
@@ -1,5 +1,5 @@
 #include "src/common.h"
-static void config_clas12(Pythia8::Pythia& pyth) {
+inline void config_clas12(Pythia8::Pythia& pyth) {
 
   // the beams are back-to-back, but with different energies; this is the recommended setting for fixed target
   set_config(pyth, "Beams:frameType = 2");


### PR DESCRIPTION
Otherwise `clangd` complains that it's unused.