### PR TITLE
fix: set `StringPT:enhancedWidth` to minimum allowed value

### DIFF
--- a/src/config/clas12.h
+++ b/src/config/clas12.h
@@ -41,7 +41,7 @@ inline void config_clas12(Pythia8::Pythia& pyth) {
 
   // fragmentation parameters
   set_config(pyth, "StringPT:enhancedFraction = 0.0"); // the fraction of string breaks with enhanced width.
-  set_config(pyth, "StringPT:enhancedWidth = 0.0");    // the enhancement of the width in this fraction.
+  set_config(pyth, "StringPT:enhancedWidth = 1.0");    // the enhancement of the width in this fraction.
   set_config(pyth, "StringZ:aLund = 1.2");             // parameters a and b of (1/z) * (1-z)^a * exp(-b m_T^2 / z)
   set_config(pyth, "StringZ:bLund = 0.58");
   set_config(pyth, "StringFragmentation:stopMass = 0.0"); // used to define a W_min = m_q1 + m_q2 + stopMass, where m_q1 and m_q2 are


### PR DESCRIPTION
We have been keeping this parameter at 0.0, which was okay in Pythia version 8.3.10; however, version 8.3.12 throws the following exception:
```
 PYTHIA Error: variable recognized, but its value is out of range:
   StringPT:enhancedWidth = 0.0
terminate called after throwing an instance of 'std::runtime_error'
  what():  bad configuration: 'StringPT:enhancedWidth = 0.0'
```
For both these Pythia versions, the minimum allowed value is 1.0.