### PR TITLE
ci: use newest Pythia version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,15 @@ jobs:
             gcc
             gcc-fortran
             git
-            make
+            make # for pythia build
             meson
             ninja
-            perl
+            perl # for documentation generation
             pkgconf
             python
+            rsync # for pythia build
             tree
-            which
+            which # for pythia build
           )
           pacman -S --noconfirm ${pkgs[*]}
           echo "[+++++] PACKAGE VERSIONS:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
             --cxx-shared="-shared -ldl"
           make -j4
           make install
-      - name: set pythia environment vars
-        run: |
+          echo "[+] set pythia environment vars:"
           echo PATH=$prefix/bin${PATH:+:${PATH}} | tee -a $GITHUB_ENV
           echo LD_LIBRARY_PATH=$prefix/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} | tee -a $GITHUB_ENV
           echo PYTHIA8DATA=$prefix/share/Pythia8/xmldoc | tee -a $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
     container:
       image: archlinux/archlinux:latest
     steps:
-      - name: git checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: update container packages
         run: pacman -Syu --noconfirm
       - name: install dependencies
@@ -51,6 +47,10 @@ jobs:
           for pkg in ${pkgs[@]}; do
             echo "$pkg: $(pacman -Qi $pkg | grep -E '^Version')"
           done
+      - name: git checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: build pythia
         run: |
           git clone https://gitlab.com/Pythia8/releases.git pythia_src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
     container:
       image: archlinux/archlinux:latest
     steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: update container packages
         run: pacman -Syu --noconfirm
       - name: install dependencies
@@ -67,10 +71,6 @@ jobs:
         run: |
           echo "## Pythia Version:" >> $GITHUB_STEP_SUMMARY
           pythia8-config --version | tee -a $GITHUB_STEP_SUMMARY
-      - name: git checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: meson setup
         run: |
           echo $PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,11 @@ jobs:
       - name: meson setup
         run: |
           echo $PATH
+          echo "-----------"
+          ls
+          echo "-----------"
+          tree pythia_install
+          echo "-----------"
           which pythia8-config
           meson setup build --prefix=$(pwd)/install
       - run: meson install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          path: stringspinner_src
       - name: build pythia
         run: |
           git clone https://gitlab.com/Pythia8/releases.git pythia_src
@@ -72,15 +73,7 @@ jobs:
           echo "## Pythia Version:" >> $GITHUB_STEP_SUMMARY
           pythia8-config --version | tee -a $GITHUB_STEP_SUMMARY
       - name: meson setup
-        run: |
-          echo $PATH
-          echo "-----------"
-          ls
-          echo "-----------"
-          tree pythia_install
-          echo "-----------"
-          which pythia8-config
-          meson setup build --prefix=$(pwd)/install
+        run: meson setup build stringspinner_src --prefix=$(pwd)/install
       - run: meson install
         working-directory: build
       - run: tree install
@@ -102,7 +95,7 @@ jobs:
       - name: generate documentation
         run: |
           mkdir publish
-          .github/generate_usage_guide.sh install/bin/clas-stringspinner |& tee publish/index.html
+          stringspinner_src/.github/generate_usage_guide.sh install/bin/clas-stringspinner |& tee publish/index.html
       - name: upload documentation
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,10 @@ jobs:
         with:
           submodules: recursive
       - name: meson setup
-        run: meson setup build --prefix=$(pwd)/install
+        run: |
+          echo $PATH
+          which pythia8-config
+          meson setup build --prefix=$(pwd)/install
       - run: meson install
         working-directory: build
       - run: tree install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             gcc
             gcc-fortran
             git
+            make
             meson
             ninja
             perl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,17 @@ jobs:
             gcc
             gcc-fortran
             git
-            make # for pythia build
             meson
             ninja
-            perl # for documentation generation
             pkgconf
             python
-            rsync # for pythia build
             tree
-            which # for pythia build
+            # additional dependencies for documentation generation
+            perl
+            # additional dependencies for pythia build
+            make
+            rsync
+            which
           )
           pacman -S --noconfirm ${pkgs[*]}
           echo "[+++++] PACKAGE VERSIONS:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
             meson
             ninja
             pkgconf
-            pythia8
             python
             perl
             tree
@@ -43,6 +42,27 @@ jobs:
           for pkg in ${pkgs[@]}; do
             echo "$pkg: $(pacman -Qi $pkg | grep -E '^Version')"
           done
+      - name: build pythia
+        run: |
+          git clone https://gitlab.com/Pythia8/releases.git pythia_src
+          prefix=$(pwd)/pythia_install
+          cd pythia_src
+          ./configure \
+            --prefix=$prefix \
+            --cxx=$(which g++) \
+            --cxx-common="-fPIC" \
+            --cxx-shared="-shared -ldl"
+          make -j4
+          make install
+      - name: set pythia environment vars
+        run: |
+          echo PATH=$prefix/bin${PATH:+:${PATH}} | tee -a $GITHUB_ENV
+          echo LD_LIBRARY_PATH=$prefix/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} | tee -a $GITHUB_ENV
+          echo PYTHIA8DATA=$prefix/share/Pythia8/xmldoc | tee -a $GITHUB_ENV
+      - name: pythia version
+        run: |
+          echo "## Pythia Version:" >> $GITHUB_STEP_SUMMARY
+          pythia8-config --version | tee -a $GITHUB_STEP_SUMMARY
       - name: git checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,11 @@ jobs:
             git
             meson
             ninja
+            perl
             pkgconf
             python
-            perl
             tree
+            which
           )
           pacman -S --noconfirm ${pkgs[*]}
           echo "[+++++] PACKAGE VERSIONS:"


### PR DESCRIPTION
Arch Linux's `pythia8` package is a couple versions behind; let's test against the _latest_ avaialble version