### PR TITLE
build: restrict to pythia 8.312

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,19 +47,17 @@ jobs:
           for pkg in ${pkgs[@]}; do
             echo "$pkg: $(pacman -Qi $pkg | grep -E '^Version')"
           done
-      - name: git checkout repo
+      - name: git checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
           path: stringspinner_src
-      - name: git checkout pythia
-        uses: actions/checkout@v4
-        with:
-          repository: https://gitlab.com/Pythia8/releases.git
-          path: pythia_src
-          ref: pythia8312 # pythia version (git tag)
       - name: build pythia
         run: |
+          git clone \
+            --revision refs/tags/pythia8312 \
+            https://gitlab.com/Pythia8/releases.git \
+            pythia_src
           prefix=$(pwd)/pythia_install
           cd pythia_src
           ./configure \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,18 @@ jobs:
           for pkg in ${pkgs[@]}; do
             echo "$pkg: $(pacman -Qi $pkg | grep -E '^Version')"
           done
-      - name: git checkout
+      - name: git checkout repo
         uses: actions/checkout@v4
         with:
           submodules: recursive
           path: stringspinner_src
+      - name: git checkout pythia
+        uses: actions/checkout@v4
+        with:
+          path: pythia_src
+          ref: pythia8312 # pythia version (git tag)
       - name: build pythia
         run: |
-          git clone https://gitlab.com/Pythia8/releases.git pythia_src
           prefix=$(pwd)/pythia_install
           cd pythia_src
           ./configure \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - name: git checkout pythia
         uses: actions/checkout@v4
         with:
+          repository: https://gitlab.com/Pythia8/releases.git
           path: pythia_src
           ref: pythia8312 # pythia version (git tag)
       - name: build pythia

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /install*
 *.lund
 *.dat
+*.png

--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,7 @@ stringspinner_proj = subproject('stringspinner')
 # dependencies
 fmt_dep           = dependency('fmt', method: 'pkg-config', version: '>= 9.1.0')
 stringspinner_dep = dependency('stringspinner', fallback: ['stringspinner', 'stringspinner_dep'])
-pythia_dep        = dependency('pythia', fallback: ['stringspinner', 'stringspinner_pythia_dep'])
+pythia_dep        = dependency('pythia', fallback: ['stringspinner', 'stringspinner_pythia_dep'], version: '8.312')
 
 # main executable
 add_project_arguments('-DCLAS_STRINGSPINNER_VERSION="' + meson.project_version() + '"', language: ['cpp'])

--- a/subprojects/stringspinner/meson.build
+++ b/subprojects/stringspinner/meson.build
@@ -24,7 +24,8 @@ endforeach
 pythia_version_res = run_command(pythia_config_prog, '--version', check: false)
 pythia_version = pythia_version_res.stdout().strip()
 if pythia_version_res.returncode() != 0 or pythia_version == ''
-  pythia_version = '8' # fallback; see https://gitlab.com/Pythia8/releases/-/issues/448
+  warning('pythia version auto-detection failed, since it is likely older than 8.312; setting version to 8.3')
+  pythia_version = '8.3' # fallback for versions < 8.312; see https://gitlab.com/Pythia8/releases/-/issues/448
 endif
 stringspinner_pythia_dep = declare_dependency(
   include_directories: run_command(pythia_config_prog, '--includedir', check: true).stdout().strip(),


### PR DESCRIPTION
This is a tight restriction, but it prevents `clas12-mcgen`'s build of Pythia8 from being "wrong" for stringspinner. We can think of a better approach to version compatibility stuff later...

We're not ready for 8.313, since that introduced some changes which impact stringspinner:

In 8.313 and 8.314, many events (maybe all of them) have the following printouts:

```
VectorMesonDecays::decay: Decayer index not correctly reconstructed.
VectorMesonDecays::decay: Letting Pythia simulate it.
```

This comes from `VectorMesonDecays.h` in Albi's code, and I've asked him about it.