### PR TITLE
feat: write particle status to Lund header user array

### DIFF
--- a/src/EventObjects.h
+++ b/src/EventObjects.h
@@ -1,4 +1,6 @@
 #include <fmt/os.h>
+#include <fmt/ranges.h>
+#include <vector>
 
 namespace clas {
 
@@ -13,7 +15,7 @@ namespace clas {
     int target_atomic_num;
     /// target spin
     double target_spin;
-    /// beam spin
+    /// beam spin (applies to the 1st `LundParticle`, actually)
     double beam_spin;
     /// beam PDG
     int beam_type;
@@ -25,11 +27,13 @@ namespace clas {
     int process_id;
     /// event weight
     double event_weight;
+    /// user values
+    std::vector<double> user_values{};
 
     /// @brief stream to output file
     /// @param output the output file stream
     void Stream(fmt::ostream& output) const {
-      output.print("{} {:.5} {:} {:} {:} {:} {:.5} {:} {:} {:.5}\n",
+      output.print("{:} {:.5} {:} {:} {:} {:} {:.5} {:} {:} {:.5}{}{:.5}\n",
           num_particles,
           target_mass,
           target_atomic_num,
@@ -39,7 +43,9 @@ namespace clas {
           beam_energy,
           nucleon_pdg,
           process_id,
-          event_weight
+          event_weight,
+          user_values.empty() ? "" : " ",
+          fmt::join(user_values, " ")
           );
     }
   };
@@ -52,8 +58,8 @@ namespace clas {
     int index;
     /// particle lifetime
     double lifetime;
-    /// particle status code
-    int status;
+    /// particle type: 1 is propagated in Geant, 0 is not
+    int type;
     /// particle PDG
     int pdg;
     /// first mother
@@ -83,7 +89,7 @@ namespace clas {
       output.print("{:} {:.5} {:} {:} {:} {:} {:.5} {:.5} {:.5} {:.5} {:.5} {:.5} {:.5} {:.5}\n",
           index,
           lifetime,
-          status,
+          type,
           pdg,
           mother1,
           daughter1,

--- a/src/EventObjects.h
+++ b/src/EventObjects.h
@@ -33,6 +33,8 @@ namespace clas {
     /// @brief stream to output file
     /// @param output the output file stream
     void Stream(fmt::ostream& output) const {
+      if(user_values.size() > 90)
+        throw std::runtime_error("LundHeader::user_values is too big");
       output.print("{:} {:.5} {:} {:} {:} {:} {:.5} {:} {:} {:.5}{}{:.5}\n",
           num_particles,
           target_mass,

--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -548,6 +548,9 @@ int main(int argc, char** argv)
     if(enable_count_before_cuts)
       evnum++;
 
+    // clear Lund header user array
+    lund_header.user_values.clear();
+
     // boost event record back to lab frame
     // see <https://gitlab.com/Pythia8/releases/-/issues/529> for details
     if(enable_patch_boost) {
@@ -667,7 +670,7 @@ int main(int argc, char** argv)
       lund_particles.push_back({
           .index     = par_index,
           .lifetime  = par.isFinal() ? 1.0 : 0.0, // not used in GEMC; FIXME: should actually be something like `par.tau() * 1e6 / SPEED_OF_LIGHT`
-          .status    = par.isFinal() ? 1 : 0,
+          .type      = par.isFinal() ? 1 : 0,
           .pdg       = par.id(),
           .mother1   = par.mother1(),
           .daughter1 = par.daughter1(),
@@ -680,6 +683,9 @@ int main(int argc, char** argv)
           .vy        = par.yProd() / 10.0, // [mm] -> [cm]
           .vz        = par.zProd() / 10.0, // [mm] -> [cm]
           });
+
+      // add particle `status` to Lund header user variables
+      lund_header.user_values.push_back(par.status());
 
       // write to kinematics table for this particle
       if(save_kin) {


### PR DESCRIPTION
Write all particles' [status code](https://pythia.org/latest-manual/ParticleProperties.html) to the user array of the Lund header; one user array element per Lund particle row.

This is temporary, so we can make cuts on ministrings; a better approach would be user columns in the particle rows, but that requires modifications downstream.