### PR TITLE
feat: control Lund-file float precision

### DIFF
--- a/src/EventObjects.h
+++ b/src/EventObjects.h
@@ -30,36 +30,38 @@ namespace clas {
     /// event weight
     double event_weight;
     /// user values
-    std::vector<double> user_values{};
+    std::vector<int> user_values{};
 
     /// @brief stream to output file
     /// @param output the output file stream
-    void Stream(fmt::ostream& output) const {
+    /// @param precision number of decimal places for floating point numbers
+    void Stream(fmt::ostream& output, int const& precision) const {
       std::size_t const user_values_max_size = 90;
       std::optional<std::string> user_values_str = std::nullopt;
       if(!user_values.empty()) {
         if(user_values.size() <= user_values_max_size) {
-          user_values_str = fmt::format(" {:.5}", fmt::join(user_values, " "));
+          user_values_str = fmt::format(" {:d}", fmt::join(user_values, " "));
         }
         else {
           clas::EventError("LundHeader::user_values is too big, with size = {}; truncating this list", user_values.size());
           decltype(user_values) user_values_trun(user_values_max_size);
           std::copy(user_values.begin(), user_values.begin() + user_values_max_size, user_values_trun.begin());
-          user_values_str = fmt::format(" {:.5}", fmt::join(user_values_trun, " "));
+          user_values_str = fmt::format(" {:d}", fmt::join(user_values_trun, " "));
         }
       }
-      output.print("{:} {:.5} {:} {:} {:} {:} {:.5} {:} {:} {:.5}{}\n",
-          num_particles,
-          target_mass,
-          target_atomic_num,
-          target_spin,
-          beam_spin,
-          beam_type,
-          beam_energy,
-          nucleon_pdg,
-          process_id,
-          event_weight,
-          user_values_str.value_or("")
+      output.print("{num_particles:d} {target_mass:.{p}f} {target_atomic_num:d} {target_spin:.{p}f} {beam_spin:.{p}f} {beam_type:d} {beam_energy:.{p}f} {nucleon_pdg:d} {process_id:d} {event_weight:.{p}f}{user_values}\n",
+          fmt::arg("num_particles", num_particles),
+          fmt::arg("target_mass", target_mass),
+          fmt::arg("target_atomic_num", target_atomic_num),
+          fmt::arg("target_spin", target_spin),
+          fmt::arg("beam_spin", beam_spin),
+          fmt::arg("beam_type", beam_type),
+          fmt::arg("beam_energy", beam_energy),
+          fmt::arg("nucleon_pdg", nucleon_pdg),
+          fmt::arg("process_id", process_id),
+          fmt::arg("event_weight", event_weight),
+          fmt::arg("user_values", user_values_str.value_or("")),
+          fmt::arg("p", precision)
           );
     }
   };
@@ -68,6 +70,7 @@ namespace clas {
 
   /// Lund particle variables
   struct LundParticle {
+
     /// particle index
     int index;
     /// particle lifetime
@@ -99,22 +102,24 @@ namespace clas {
 
     /// @brief stream to output file
     /// @param output the output file stream
-    void Stream(fmt::ostream& output) const {
-      output.print("{:} {:.5} {:} {:} {:} {:} {:.5} {:.5} {:.5} {:.5} {:.5} {:.5} {:.5} {:.5}\n",
-          index,
-          lifetime,
-          type,
-          pdg,
-          mother1,
-          daughter1,
-          px,
-          py,
-          pz,
-          energy,
-          mass,
-          vx,
-          vy,
-          vz
+    /// @param precision number of decimal places for floating point numbers
+    void Stream(fmt::ostream& output, int const& precision) const {
+      output.print("{index:d} {lifetime:.{p}f} {type:d} {pdg:d} {mother1:d} {daughter1:d} {px:.{p}f} {py:.{p}f} {pz:.{p}f} {energy:.{p}f} {mass:.{p}f} {vx:.{p}f} {vy:.{p}f} {vz:.{p}f}\n",
+          fmt::arg("index", index),
+          fmt::arg("lifetime", lifetime),
+          fmt::arg("type", type),
+          fmt::arg("pdg", pdg),
+          fmt::arg("mother1", mother1),
+          fmt::arg("daughter1", daughter1),
+          fmt::arg("px", px),
+          fmt::arg("py", py),
+          fmt::arg("pz", pz),
+          fmt::arg("energy", energy),
+          fmt::arg("mass", mass),
+          fmt::arg("vx", vx),
+          fmt::arg("vy", vy),
+          fmt::arg("vz", vz),
+          fmt::arg("p", precision)
           );
     }
   };

--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -30,6 +30,7 @@ std::string const obj_name[nObj] = { "beam", "target" };
 // default option values
 static unsigned long            num_events               = 10000;
 static std::string              out_file_name            = "clas-stringspinner.dat";
+static int                      precision                = 5;
 static bool                     save_kin                 = false;
 static double                   beam_energy              = 10.60410;
 static double                   target_beam_energy       = 0;
@@ -76,6 +77,9 @@ OUTPUT FILE CONTROL:
 
   --out-file OUTPUT_FILE           output Lund file name
                                    default: {out_file_name:?}
+
+  --precision PRECISION            number of decimal places for Lund-file floats
+                                   default: {precision}
 
   --save-kin                       if set, calculate additional kinematics and save
                                    them to a tables with filenames
@@ -183,6 +187,7 @@ OPTIONS FOR OSG COMPATIBILITY:
       fmt::arg("patch_boost", patch_boost),
       fmt::arg("num_events", num_events),
       fmt::arg("out_file_name", out_file_name),
+      fmt::arg("precision", precision),
       fmt::arg("beam_energy", beam_energy),
       fmt::arg("target_type", target_type),
       fmt::arg("target_beam_energy", target_beam_energy),
@@ -227,7 +232,8 @@ int main(int argc, char** argv)
   enum options_enum {
     opt_num_events,
     opt_docker,
-    opt_out_file,
+    opt_out_file_name,
+    opt_precision,
     opt_save_kin,
     opt_beam_energy,
     opt_target_beam_energy,
@@ -251,7 +257,8 @@ int main(int argc, char** argv)
     {"num-events",         required_argument, nullptr, opt_num_events},
     {"trig",               required_argument, nullptr, opt_num_events},
     {"docker",             no_argument,       nullptr, opt_docker},
-    {"out-file",           required_argument, nullptr, opt_out_file},
+    {"out-file",           required_argument, nullptr, opt_out_file_name},
+    {"precision",          required_argument, nullptr, opt_precision},
     {"save-kin",           no_argument,       nullptr, opt_save_kin},
     {"beam-energy",        required_argument, nullptr, opt_beam_energy},
     {"ebeam",              required_argument, nullptr, opt_beam_energy},
@@ -283,7 +290,8 @@ int main(int argc, char** argv)
   while((opt = getopt_long(argc, argv, "", opts, nullptr)) != -1) {
     switch(opt) {
       case opt_num_events: num_events = std::stol(optarg); break;
-      case opt_out_file: out_file_name = std::string(optarg); break;
+      case opt_out_file_name: out_file_name = std::string(optarg); break;
+      case opt_precision: precision = std::stoi(optarg); break;
       case opt_save_kin: save_kin = true; break;
       case opt_beam_energy: beam_energy = std::stod(optarg); break;
       case opt_target_beam_energy: target_beam_energy = std::stod(optarg); break;
@@ -324,6 +332,7 @@ int main(int argc, char** argv)
     fmt::println("{:>30} = {}", "num-events", num_events);
     fmt::println("{:>30} = {}", "count-before-cuts", enable_count_before_cuts ? "true" : "false");
     fmt::println("{:>30} = {:?}", "out-file", out_file_name);
+    fmt::println("{:>30} = {}", "precision", precision);
     fmt::println("{:>30} = {} GeV", "beam-energy", beam_energy);
     fmt::println("{:>30} = {:?}", "target-type", target_type);
     fmt::println("{:>30} = {} GeV", "target-beam-energy", target_beam_energy);
@@ -735,9 +744,9 @@ int main(int argc, char** argv)
     lund_header.event_weight  = pyth.info.weight();
 
     // stream to lund file
-    lund_header.Stream(lund_file);
+    lund_header.Stream(lund_file, precision);
     for(auto const& lund_particle : lund_particles)
-      lund_particle.Stream(lund_file);
+      lund_particle.Stream(lund_file, precision);
 
     // finalize
     if(!enable_count_before_cuts) {


### PR DESCRIPTION
Harut was having trouble reading the Lund files, since:
- float `1.0000` would be printed as `1`, and would be parsed as a Fortran integer rather than a real
- small numbers, such as `1-e7`, may have also been causing parsing troubles

Instead, choose the number of decimal places up front.