### PR TITLE
ci: use `container-forge` image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,34 +19,10 @@ jobs:
   stringspinner:
     runs-on: ubuntu-latest
     container:
-      image: archlinux/archlinux:latest
+      image: codecr.jlab.org/hallb/clas12/container-forge/base_root
     steps:
       - name: update container packages
         run: pacman -Syu --noconfirm
-      - name: install dependencies
-        run: |
-          pkgs=(
-            fmt
-            gcc
-            gcc-fortran
-            git
-            meson
-            ninja
-            pkgconf
-            python
-            tree
-            # additional dependencies for documentation generation
-            perl
-            # additional dependencies for pythia build
-            make
-            rsync
-            which
-          )
-          pacman -S --noconfirm ${pkgs[*]}
-          echo "[+++++] PACKAGE VERSIONS:"
-          for pkg in ${pkgs[@]}; do
-            echo "$pkg: $(pacman -Qi $pkg | grep -E '^Version')"
-          done
       - name: git checkout
         uses: actions/checkout@v4
         with:
@@ -55,7 +31,9 @@ jobs:
       - name: build pythia
         run: |
           git clone \
-            --revision refs/tags/pythia8312 \
+            --depth 1 \
+            --single-branch \
+            --branch pythia8312 \
             https://gitlab.com/Pythia8/releases.git \
             pythia_src
           prefix=$(pwd)/pythia_install


### PR DESCRIPTION
The next PR will optionally include `hipo-cpp` dependence, so let's use a `container-forge` base image which already has it.