### PR TITLE
feat: HIPO file output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         run: install/bin/clas-stringspinner --num-events 1
       - name: test OSG options
         run: install/bin/clas-stringspinner --trig 10 --docker --seed 1448577483 # see `clas12-mcgen` documentation
+      - name: test HIPO output
+        run: install/bin/clas-stringspinner --num-events 10 --save-hipo
       - name: test relocatability
         run: |
           mkdir relocated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   stringspinner:
     runs-on: ubuntu-latest
     container:
-      image: codecr.jlab.org/hallb/clas12/container-forge/base
+      image: codecr.jlab.org/hallb/clas12/container-forge/base:MR-318-141
     steps:
       - name: update container packages
         run: pacman -Syu --noconfirm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   stringspinner:
     runs-on: ubuntu-latest
     container:
-      image: codecr.jlab.org/hallb/clas12/container-forge/base:MR-318-141
+      image: codecr.jlab.org/hallb/clas12/container-forge/base:latest
     steps:
       - name: update container packages
         run: pacman -Syu --noconfirm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   stringspinner:
     runs-on: ubuntu-latest
     container:
-      image: codecr.jlab.org/hallb/clas12/container-forge/base_root
+      image: codecr.jlab.org/hallb/clas12/container-forge/base
     steps:
       - name: update container packages
         run: pacman -Syu --noconfirm

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+# ignore submodules
+subprojects/stringspinner/stringspinner/**

--- a/meson.build
+++ b/meson.build
@@ -18,14 +18,20 @@ stringspinner_proj = subproject('stringspinner')
 fmt_dep           = dependency('fmt', method: 'pkg-config', version: '>= 9.1.0')
 stringspinner_dep = dependency('stringspinner', fallback: ['stringspinner', 'stringspinner_dep'])
 pythia_dep        = dependency('pythia', fallback: ['stringspinner', 'stringspinner_pythia_dep'], version: '8.312')
+hipo_dep          = dependency('hipo4', method: 'pkg-config', required: false, version: '>=4.2.0')
+
+# preprocessor macros
+add_project_arguments('-D CLAS_STRINGSPINNER_VERSION="' + meson.project_version() + '"', language: ['cpp'])
+if hipo_dep.found()
+  add_project_arguments('-D CLAS_STRINGSPINNER_HIPO', language: ['cpp'])
+endif
 
 # main executable
-add_project_arguments('-DCLAS_STRINGSPINNER_VERSION="' + meson.project_version() + '"', language: ['cpp'])
 main_exe = executable(
   meson.project_name(),
   'src' / meson.project_name() + '.cpp',
   'src' / 'config' / 'src' / 'common.cc',
-  dependencies: [ fmt_dep, stringspinner_dep, pythia_dep ],
+  dependencies: [ fmt_dep, stringspinner_dep, pythia_dep, hipo_dep ],
   install: true,
 )
 

--- a/src/CheckList.h
+++ b/src/CheckList.h
@@ -3,7 +3,7 @@
 #include "Kinematics.h"
 #include "Tools.h"
 
-namespace clas {
+namespace css {
 
   /// @brief checklist for particle cuts
   class CheckList {

--- a/src/CheckList.h
+++ b/src/CheckList.h
@@ -3,7 +3,7 @@
 #include "Kinematics.h"
 #include "Tools.h"
 
-namespace css {
+namespace string_spinner {
 
   /// @brief checklist for particle cuts
   class CheckList {

--- a/src/Hipo.h
+++ b/src/Hipo.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "Lund.h"
+
+#ifdef CLAS_STRINGSPINNER_HIPO
+#include <hipo4/writer.h>
+
+namespace css {
+
+  class Hipo {
+
+    private:
+      hipo::writer writer;
+      hipo::event event;
+      hipo::schema s_mc_particle{"MC::Particle", 40, 2};
+      hipo::bank b_mc_particle;
+
+    public: // ==================================================================================
+
+      Hipo(std::string hipo_file_name)
+      {
+        s_mc_particle.parse("pid/I,px/F,py/F,pz/F,vx/F,vy/F,vz/F,vt/F");
+        writer.getDictionary().addSchema(s_mc_particle);
+        b_mc_particle = hipo::bank(s_mc_particle);
+        writer.open(hipo_file_name.c_str());
+      }
+
+      // ==================================================================================
+
+      void SetNumParticles(int const num)
+      {
+        b_mc_particle.setRows(num);
+      }
+
+      // ==================================================================================
+
+      void FillParticle(LundParticle const& lund, int const& row)
+      {
+        b_mc_particle.putInt("pid", row, lund.pdg);
+        b_mc_particle.putFloat("px", row, lund.px);
+        b_mc_particle.putFloat("py", row, lund.py);
+        b_mc_particle.putFloat("pz", row, lund.pz);
+        b_mc_particle.putFloat("vx", row, lund.vx);
+        b_mc_particle.putFloat("vy", row, lund.vy);
+        b_mc_particle.putFloat("vz", row, lund.vz);
+        b_mc_particle.putFloat("vt", row, 0);
+      }
+
+      // ==================================================================================
+
+      void Write()
+      {
+        event.reset();
+        event.addStructure(b_mc_particle);
+        writer.addEvent(event);
+        b_mc_particle.reset();
+      }
+
+      // ==================================================================================
+
+      void Close()
+      {
+        writer.close();
+      }
+
+  };
+}
+#endif

--- a/src/Hipo.h
+++ b/src/Hipo.h
@@ -2,7 +2,6 @@
 
 #include "Lund.h"
 
-#ifdef CLAS_STRINGSPINNER_HIPO
 #include <hipo4/writer.h>
 
 namespace css {
@@ -10,59 +9,87 @@ namespace css {
   class Hipo {
 
     private:
+#ifdef CLAS_STRINGSPINNER_HIPO
       hipo::writer writer;
       hipo::event event;
+      hipo::schema s_mc_event{"MC::Event", 40, 1};
       hipo::schema s_mc_particle{"MC::Particle", 40, 2};
+      hipo::bank b_mc_event;
       hipo::bank b_mc_particle;
+#endif
 
     public: // ==================================================================================
 
       Hipo(std::string hipo_file_name)
       {
+#ifdef CLAS_STRINGSPINNER_HIPO
+        s_mc_event.parse("npart/S,atarget/S,ztarget/S,ptarget/F,pbeam/F,btype/S,ebeam/F,targetid/S,processid/S,weight/F");
         s_mc_particle.parse("pid/I,px/F,py/F,pz/F,vx/F,vy/F,vz/F,vt/F");
+        writer.getDictionary().addSchema(s_mc_event);
         writer.getDictionary().addSchema(s_mc_particle);
+        b_mc_event    = hipo::bank(s_mc_event);
         b_mc_particle = hipo::bank(s_mc_particle);
         writer.open(hipo_file_name.c_str());
+#else
+        throw std::runtime_error("HIPO file output was not enabled for this build of clas-stringspinner");
+#endif
       }
 
       // ==================================================================================
 
-      void SetNumParticles(int const num)
+      void Stream(LundHeader const& head, std::vector<LundParticle> const& pars)
       {
-        b_mc_particle.setRows(num);
-      }
-
-      // ==================================================================================
-
-      void FillParticle(LundParticle const& lund, int const& row)
-      {
-        b_mc_particle.putInt("pid", row, lund.pdg);
-        b_mc_particle.putFloat("px", row, lund.px);
-        b_mc_particle.putFloat("py", row, lund.py);
-        b_mc_particle.putFloat("pz", row, lund.pz);
-        b_mc_particle.putFloat("vx", row, lund.vx);
-        b_mc_particle.putFloat("vy", row, lund.vy);
-        b_mc_particle.putFloat("vz", row, lund.vz);
-        b_mc_particle.putFloat("vt", row, 0);
-      }
-
-      // ==================================================================================
-
-      void Write()
-      {
+#ifdef CLAS_STRINGSPINNER_HIPO
+        // filter `pars` by `Pythia::Particle::isFinal()` (i.e. `type==1`)
+        std::vector<LundParticle> pars_final;
+        for(auto par : pars)
+          if(par.type == 1)
+            pars_final.push_back(par);
+        // fill `MC::Event`
+        b_mc_event.setRows(1);
+        b_mc_event.putShort("npart",     0, head.num_particles);
+        b_mc_event.putShort("atarget",   0, head.target_mass);
+        b_mc_event.putShort("ztarget",   0, head.target_atomic_num);
+        b_mc_event.putFloat("ptarget",   0, head.target_spin);
+        b_mc_event.putFloat("pbeam",     0, head.beam_spin);
+        b_mc_event.putShort("btype",     0, head.beam_type);
+        b_mc_event.putFloat("ebeam",     0, head.beam_energy);
+        b_mc_event.putShort("targetid",  0, head.nucleon_pdg);
+        b_mc_event.putShort("processid", 0, head.process_id);
+        b_mc_event.putFloat("weight",    0, head.event_weight);
+        // fill `MC::Particle`
+        b_mc_particle.setRows(pars_final.size());
+        int i_par = 0;
+        for(auto const& par : pars_final) {
+          b_mc_particle.putInt("pid",  i_par, par.pdg);
+          b_mc_particle.putFloat("px", i_par, par.px);
+          b_mc_particle.putFloat("py", i_par, par.py);
+          b_mc_particle.putFloat("pz", i_par, par.pz);
+          b_mc_particle.putFloat("vx", i_par, par.vx);
+          b_mc_particle.putFloat("vy", i_par, par.vy);
+          b_mc_particle.putFloat("vz", i_par, par.vz);
+          b_mc_particle.putFloat("vt", i_par, 0);
+          i_par++;
+        }
+        // write
         event.reset();
+        event.addStructure(b_mc_event);
         event.addStructure(b_mc_particle);
         writer.addEvent(event);
+        // reset
+        b_mc_event.reset();
         b_mc_particle.reset();
+#endif
       }
 
       // ==================================================================================
 
       void Close()
       {
+#ifdef CLAS_STRINGSPINNER_HIPO
         writer.close();
+#endif
       }
 
   };
 }
-#endif

--- a/src/Hipo.h
+++ b/src/Hipo.h
@@ -12,10 +12,14 @@ namespace css {
 #ifdef CLAS_STRINGSPINNER_HIPO
       hipo::writer writer;
       hipo::event event;
+      hipo::schema s_mc_header{"MC::Header", 40, 0};
       hipo::schema s_mc_event{"MC::Event", 40, 1};
       hipo::schema s_mc_particle{"MC::Particle", 40, 2};
+      hipo::schema s_mc_lund{"MC::Lund", 40, 3};
+      hipo::bank b_mc_header;
       hipo::bank b_mc_event;
       hipo::bank b_mc_particle;
+      hipo::bank b_mc_lund;
 #endif
 
     public: // ==================================================================================
@@ -23,12 +27,18 @@ namespace css {
       Hipo(std::string hipo_file_name)
       {
 #ifdef CLAS_STRINGSPINNER_HIPO
+        s_mc_header.parse("run/I,event/I,type/B,helicity/F");
         s_mc_event.parse("npart/S,atarget/S,ztarget/S,ptarget/F,pbeam/F,btype/S,ebeam/F,targetid/S,processid/S,weight/F");
         s_mc_particle.parse("pid/I,px/F,py/F,pz/F,vx/F,vy/F,vz/F,vt/F");
+        s_mc_lund.parse("index/B,lifetime/F,type/B,pid/I,parent/B,daughter/B,px/F,py/F,pz/F,energy/F,mass/F,vx/F,vy/F,vz/F");
+        writer.getDictionary().addSchema(s_mc_header);
         writer.getDictionary().addSchema(s_mc_event);
         writer.getDictionary().addSchema(s_mc_particle);
+        writer.getDictionary().addSchema(s_mc_lund);
+        b_mc_header   = hipo::bank(s_mc_header);
         b_mc_event    = hipo::bank(s_mc_event);
         b_mc_particle = hipo::bank(s_mc_particle);
+        b_mc_lund     = hipo::bank(s_mc_lund);
         writer.open(hipo_file_name.c_str());
 #else
         throw std::runtime_error("HIPO file output was not enabled for this build of clas-stringspinner");
@@ -37,14 +47,19 @@ namespace css {
 
       // ==================================================================================
 
-      void Stream(LundHeader const& head, std::vector<LundParticle> const& pars)
+      void Stream(
+          LundHeader const& head,
+          std::vector<LundParticle> const& pars,
+          css::evnum_t evnum
+          )
       {
 #ifdef CLAS_STRINGSPINNER_HIPO
-        // filter `pars` by `Pythia::Particle::isFinal()` (i.e. `type==1`)
-        std::vector<LundParticle> pars_final;
-        for(auto par : pars)
-          if(par.type == 1)
-            pars_final.push_back(par);
+        // fill `MC::Header`
+        b_mc_header.setRows(1);
+        b_mc_header.putInt("run",        0, 11);
+        b_mc_header.putInt("event",      0, static_cast<int>(evnum));
+        b_mc_header.putByte("type",      0, 0);
+        b_mc_header.putFloat("helicity", 0, head.beam_spin);
         // fill `MC::Event`
         b_mc_event.setRows(1);
         b_mc_event.putShort("npart",     0, head.num_particles);
@@ -58,6 +73,10 @@ namespace css {
         b_mc_event.putShort("processid", 0, head.process_id);
         b_mc_event.putFloat("weight",    0, head.event_weight);
         // fill `MC::Particle`
+        std::vector<LundParticle> pars_final; // `pars` with `Pythia::Particle::isFinal()` (i.e. `type==1`)
+        for(auto par : pars)
+          if(par.type == 1)
+            pars_final.push_back(par);
         b_mc_particle.setRows(pars_final.size());
         int i_par = 0;
         for(auto const& par : pars_final) {
@@ -71,14 +90,38 @@ namespace css {
           b_mc_particle.putFloat("vt", i_par, 0);
           i_par++;
         }
+        // fill `MC::Lund`
+        b_mc_lund.setRows(pars.size());
+        i_par = 0;
+        for(auto const& par : pars) {
+          b_mc_lund.putByte("index",     i_par, par.index);
+          b_mc_lund.putFloat("lifetime", i_par, par.lifetime);
+          b_mc_lund.putByte("type",      i_par, par.type);
+          b_mc_lund.putInt("pid",        i_par, par.pdg);
+          b_mc_lund.putByte("parent",    i_par, par.mother1);
+          b_mc_lund.putByte("daughter",  i_par, par.daughter1);
+          b_mc_lund.putFloat("px",       i_par, par.px);
+          b_mc_lund.putFloat("py",       i_par, par.py);
+          b_mc_lund.putFloat("pz",       i_par, par.pz);
+          b_mc_lund.putFloat("energy",   i_par, par.energy);
+          b_mc_lund.putFloat("mass",     i_par, par.mass);
+          b_mc_lund.putFloat("vx",       i_par, par.vx);
+          b_mc_lund.putFloat("vy",       i_par, par.vy);
+          b_mc_lund.putFloat("vz",       i_par, par.vz);
+          i_par++;
+        }
         // write
         event.reset();
+        event.addStructure(b_mc_header);
         event.addStructure(b_mc_event);
         event.addStructure(b_mc_particle);
+        event.addStructure(b_mc_lund);
         writer.addEvent(event);
         // reset
+        b_mc_header.reset();
         b_mc_event.reset();
         b_mc_particle.reset();
+        b_mc_lund.reset();
 #endif
       }
 

--- a/src/Hipo.h
+++ b/src/Hipo.h
@@ -59,21 +59,21 @@ namespace string_spinner {
         // fill `MC::Header`
         b_mc_header.setRows(1);
         b_mc_header.putInt("run",        0, 11);
-        b_mc_header.putInt("event",      0, static_cast<int>(evnum));
+        b_mc_header.putInt("event",      0, static_cast<int32_t>(evnum));
         b_mc_header.putByte("type",      0, 0);
-        b_mc_header.putFloat("helicity", 0, head.beam_spin);
+        b_mc_header.putFloat("helicity", 0, static_cast<float>(head.beam_spin));
         // fill `MC::Event`
         b_mc_event.setRows(1);
-        b_mc_event.putShort("npart",     0, head.num_particles);
-        b_mc_event.putShort("atarget",   0, head.target_mass);
-        b_mc_event.putShort("ztarget",   0, head.target_atomic_num);
-        b_mc_event.putFloat("ptarget",   0, head.target_spin);
-        b_mc_event.putFloat("pbeam",     0, head.beam_spin);
-        b_mc_event.putShort("btype",     0, head.beam_type);
-        b_mc_event.putFloat("ebeam",     0, head.beam_energy);
-        b_mc_event.putShort("targetid",  0, head.nucleon_pdg);
-        b_mc_event.putShort("processid", 0, head.process_id);
-        b_mc_event.putFloat("weight",    0, head.event_weight);
+        b_mc_event.putShort("npart",     0, static_cast<int16_t>(head.num_particles));
+        b_mc_event.putShort("atarget",   0, static_cast<int16_t>(head.target_mass_num));
+        b_mc_event.putShort("ztarget",   0, static_cast<int16_t>(head.target_atomic_num));
+        b_mc_event.putFloat("ptarget",   0, static_cast<float>(head.target_spin));
+        b_mc_event.putFloat("pbeam",     0, static_cast<float>(head.beam_spin));
+        b_mc_event.putShort("btype",     0, static_cast<int16_t>(head.beam_type));
+        b_mc_event.putFloat("ebeam",     0, static_cast<float>(head.beam_energy));
+        b_mc_event.putShort("targetid",  0, static_cast<int16_t>(head.nucleon_pdg));
+        b_mc_event.putShort("processid", 0, static_cast<int16_t>(head.process_id));
+        b_mc_event.putFloat("weight",    0, static_cast<float>(head.event_weight));
         // fill `MC::Particle`
         std::vector<LundParticle> pars_final; // `pars` with `Pythia::Particle::isFinal()` (i.e. `type==1`)
         for(auto par : pars)
@@ -82,13 +82,13 @@ namespace string_spinner {
         b_mc_particle.setRows(pars_final.size());
         int i_par = 0;
         for(auto const& par : pars_final) {
-          b_mc_particle.putInt("pid",  i_par, par.pdg);
-          b_mc_particle.putFloat("px", i_par, par.px);
-          b_mc_particle.putFloat("py", i_par, par.py);
-          b_mc_particle.putFloat("pz", i_par, par.pz);
-          b_mc_particle.putFloat("vx", i_par, par.vx);
-          b_mc_particle.putFloat("vy", i_par, par.vy);
-          b_mc_particle.putFloat("vz", i_par, par.vz);
+          b_mc_particle.putInt("pid",  i_par, static_cast<int32_t>(par.pdg));
+          b_mc_particle.putFloat("px", i_par, static_cast<float>(par.px));
+          b_mc_particle.putFloat("py", i_par, static_cast<float>(par.py));
+          b_mc_particle.putFloat("pz", i_par, static_cast<float>(par.pz));
+          b_mc_particle.putFloat("vx", i_par, static_cast<float>(par.vx));
+          b_mc_particle.putFloat("vy", i_par, static_cast<float>(par.vy));
+          b_mc_particle.putFloat("vz", i_par, static_cast<float>(par.vz));
           b_mc_particle.putFloat("vt", i_par, 0);
           i_par++;
         }
@@ -96,30 +96,30 @@ namespace string_spinner {
         b_mc_lund.setRows(pars.size());
         i_par = 0;
         for(auto const& par : pars) {
-          b_mc_lund.putByte("index",     i_par, par.index);
-          b_mc_lund.putFloat("lifetime", i_par, par.lifetime);
-          b_mc_lund.putByte("type",      i_par, par.type);
-          b_mc_lund.putInt("pid",        i_par, par.pdg);
-          b_mc_lund.putByte("parent",    i_par, par.mother1);
-          b_mc_lund.putByte("daughter",  i_par, par.daughter1);
-          b_mc_lund.putFloat("px",       i_par, par.px);
-          b_mc_lund.putFloat("py",       i_par, par.py);
-          b_mc_lund.putFloat("pz",       i_par, par.pz);
-          b_mc_lund.putFloat("energy",   i_par, par.energy);
-          b_mc_lund.putFloat("mass",     i_par, par.mass);
-          b_mc_lund.putFloat("vx",       i_par, par.vx);
-          b_mc_lund.putFloat("vy",       i_par, par.vy);
-          b_mc_lund.putFloat("vz",       i_par, par.vz);
+          b_mc_lund.putByte("index",     i_par, static_cast<int8_t>(par.index));
+          b_mc_lund.putFloat("lifetime", i_par, static_cast<float>(par.lifetime));
+          b_mc_lund.putByte("type",      i_par, static_cast<int8_t>(par.type));
+          b_mc_lund.putInt("pid",        i_par, static_cast<int32_t>(par.pdg));
+          b_mc_lund.putByte("parent",    i_par, static_cast<int8_t>(par.mother1));
+          b_mc_lund.putByte("daughter",  i_par, static_cast<int8_t>(par.daughter1));
+          b_mc_lund.putFloat("px",       i_par, static_cast<float>(par.px));
+          b_mc_lund.putFloat("py",       i_par, static_cast<float>(par.py));
+          b_mc_lund.putFloat("pz",       i_par, static_cast<float>(par.pz));
+          b_mc_lund.putFloat("energy",   i_par, static_cast<float>(par.energy));
+          b_mc_lund.putFloat("mass",     i_par, static_cast<float>(par.mass));
+          b_mc_lund.putFloat("vx",       i_par, static_cast<float>(par.vx));
+          b_mc_lund.putFloat("vy",       i_par, static_cast<float>(par.vy));
+          b_mc_lund.putFloat("vz",       i_par, static_cast<float>(par.vz));
           i_par++;
         }
         // write
-        event.reset();
         event.addStructure(b_mc_header);
         event.addStructure(b_mc_event);
         event.addStructure(b_mc_particle);
         event.addStructure(b_mc_lund);
         writer.addEvent(event);
         // reset
+        event.reset();
         b_mc_header.reset();
         b_mc_event.reset();
         b_mc_particle.reset();

--- a/src/Hipo.h
+++ b/src/Hipo.h
@@ -2,9 +2,11 @@
 
 #include "Lund.h"
 
+#ifdef CLAS_STRINGSPINNER_HIPO
 #include <hipo4/writer.h>
+#endif
 
-namespace css {
+namespace string_spinner {
 
   class Hipo {
 
@@ -50,7 +52,7 @@ namespace css {
       void Stream(
           LundHeader const& head,
           std::vector<LundParticle> const& pars,
-          css::evnum_t evnum
+          string_spinner::evnum_t evnum
           )
       {
 #ifdef CLAS_STRINGSPINNER_HIPO

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -3,10 +3,9 @@
 #include <fmt/os.h>
 #include <fmt/ranges.h>
 #include <Pythia8/Event.h>
+#include "Tools.h"
 
 namespace css {
-
-  using evnum_t = unsigned long;
 
   // ==================================================================================
 

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -4,7 +4,7 @@
 #include <fmt/ranges.h>
 #include <Pythia8/Event.h>
 
-namespace clas {
+namespace css {
 
   using evnum_t = unsigned long;
 

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -5,7 +5,7 @@
 #include <Pythia8/Event.h>
 #include "Tools.h"
 
-namespace css {
+namespace string_spinner {
 
   // ==================================================================================
 

--- a/src/Lund.h
+++ b/src/Lund.h
@@ -6,7 +6,7 @@
 #include <Pythia8/Event.h>
 #include "Tools.h"
 
-namespace clas {
+namespace css {
 
   /// Lund event header variables
   struct LundHeader {
@@ -34,7 +34,7 @@ namespace clas {
           user_values_str = fmt::format(" {:d}", fmt::join(user_values, " "));
         }
         else {
-          clas::EventError("LundHeader::user_values is too big, with size = {}; truncating this list", user_values.size());
+          css::EventError("LundHeader::user_values is too big, with size = {}; truncating this list", user_values.size());
           decltype(user_values) user_values_trun(user_values_max_size);
           std::copy(user_values.begin(), user_values.begin() + user_values_max_size, user_values_trun.begin());
           user_values_str = fmt::format(" {:d}", fmt::join(user_values_trun, " "));

--- a/src/Lund.h
+++ b/src/Lund.h
@@ -11,16 +11,16 @@ namespace css {
   /// Lund event header variables
   struct LundHeader {
 
-    int num_particles; /// number of particles in the event
-    double target_mass; /// target mass
-    int target_atomic_num; /// target atomic number
-    double target_spin; /// target spin
-    double beam_spin; /// beam spin (applies to the 1st `LundParticle`, actually)
-    int beam_type; /// beam PDG
-    double beam_energy; /// beam energy
-    int nucleon_pdg; /// target nucleon PDG
-    int process_id; /// pythia process code
-    double event_weight; /// event weight
+    int    num_particles;     /// number of particles in the event
+    double target_mass;       /// target mass
+    int    target_atomic_num; /// target atomic number
+    double target_spin;       /// target spin
+    double beam_spin;         /// beam spin (applies to the 1st `LundParticle`, actually)
+    int    beam_type;         /// beam PDG
+    double beam_energy;       /// beam energy
+    int    nucleon_pdg;       /// target nucleon PDG
+    int    process_id;        /// pythia process code
+    double event_weight;      /// event weight
     std::vector<int> user_values{}; /// user values
 
     /// @brief stream to output file
@@ -62,20 +62,20 @@ namespace css {
   /// Lund particle variables
   struct LundParticle {
 
-    int index; /// particle index
-    double lifetime; /// particle lifetime
-    int type; /// particle type: 1 is propagated in Geant, 0 is not
-    int pdg; /// particle PDG
-    int mother1; /// first mother
-    int daughter1; /// first daughter
-    double px; /// particle momentum x-component
-    double py; /// particle momentum y-component
-    double pz; /// particle momentum z-component
-    double energy; /// particle energy
-    double mass; /// particle mass
-    double vx; /// particle vertex x-component
-    double vy; /// particle vertex y-component
-    double vz; /// particle vertex z-component
+    int    index;     /// particle index
+    double lifetime;  /// particle lifetime
+    int    type;      /// particle type: 1 is propagated in Geant, 0 is not
+    int    pdg;       /// particle PDG
+    int    mother1;   /// first mother
+    int    daughter1; /// first daughter
+    double px;        /// particle momentum x-component
+    double py;        /// particle momentum y-component
+    double pz;        /// particle momentum z-component
+    double energy;    /// particle energy
+    double mass;      /// particle mass
+    double vx;        /// particle vertex x-component
+    double vy;        /// particle vertex y-component
+    double vz;        /// particle vertex z-component
 
     /// @brief stream to output file
     /// @param output the output file stream

--- a/src/Lund.h
+++ b/src/Lund.h
@@ -11,17 +11,18 @@ namespace string_spinner {
   /// Lund event header variables
   struct LundHeader {
 
-    int    num_particles;     /// number of particles in the event
-    double target_mass;       /// target mass
-    int    target_atomic_num; /// target atomic number
-    double target_spin;       /// target spin
-    double beam_spin;         /// beam spin (applies to the 1st `LundParticle`, actually)
-    int    beam_type;         /// beam PDG
-    double beam_energy;       /// beam energy
-    int    nucleon_pdg;       /// target nucleon PDG
-    int    process_id;        /// pythia process code
-    double event_weight;      /// event weight
-    std::vector<int> user_values{}; /// user values
+    int    num_particles;     ///< number of particles in the event
+    double target_mass;       ///< target mass
+    int    target_atomic_num; ///< target atomic number (Z, the number of protons)
+    int    target_mass_num;   ///< target mass number (A, the number of protons + neutrons); not printed to Lund files
+    double target_spin;       ///< target spin
+    double beam_spin;         ///< beam spin (applies to the 1st `LundParticle`, actually)
+    int    beam_type;         ///< beam PDG
+    double beam_energy;       ///< beam energy
+    int    nucleon_pdg;       ///< target nucleon PDG
+    int    process_id;        ///< pythia process code
+    double event_weight;      ///< event weight
+    std::vector<int> user_values{}; ///< user values
 
     /// @brief stream to output file
     /// @param output the output file stream
@@ -62,20 +63,20 @@ namespace string_spinner {
   /// Lund particle variables
   struct LundParticle {
 
-    int    index;     /// particle index
-    double lifetime;  /// particle lifetime
-    int    type;      /// particle type: 1 is propagated in Geant, 0 is not
-    int    pdg;       /// particle PDG
-    int    mother1;   /// first mother
-    int    daughter1; /// first daughter
-    double px;        /// particle momentum x-component
-    double py;        /// particle momentum y-component
-    double pz;        /// particle momentum z-component
-    double energy;    /// particle energy
-    double mass;      /// particle mass
-    double vx;        /// particle vertex x-component
-    double vy;        /// particle vertex y-component
-    double vz;        /// particle vertex z-component
+    int    index;     ///< particle index
+    double lifetime;  ///< particle lifetime
+    int    type;      ///< particle type: 1 is propagated in Geant, 0 is not
+    int    pdg;       ///< particle PDG
+    int    mother1;   ///< first mother
+    int    daughter1; ///< first daughter
+    double px;        ///< particle momentum x-component
+    double py;        ///< particle momentum y-component
+    double pz;        ///< particle momentum z-component
+    double energy;    ///< particle energy
+    double mass;      ///< particle mass
+    double vx;        ///< particle vertex x-component
+    double vy;        ///< particle vertex y-component
+    double vz;        ///< particle vertex z-component
 
     /// @brief stream to output file
     /// @param output the output file stream

--- a/src/Lund.h
+++ b/src/Lund.h
@@ -6,7 +6,7 @@
 #include <Pythia8/Event.h>
 #include "Tools.h"
 
-namespace css {
+namespace string_spinner {
 
   /// Lund event header variables
   struct LundHeader {
@@ -34,7 +34,7 @@ namespace css {
           user_values_str = fmt::format(" {:d}", fmt::join(user_values, " "));
         }
         else {
-          css::EventError("LundHeader::user_values is too big, with size = {}; truncating this list", user_values.size());
+          string_spinner::EventError("LundHeader::user_values is too big, with size = {}; truncating this list", user_values.size());
           decltype(user_values) user_values_trun(user_values_max_size);
           std::copy(user_values.begin(), user_values.begin() + user_values_max_size, user_values_trun.begin());
           user_values_str = fmt::format(" {:d}", fmt::join(user_values_trun, " "));

--- a/src/Tools.h
+++ b/src/Tools.h
@@ -7,6 +7,9 @@
 /// namespace for `clas-stringspinner` (abbreviated as "css")
 namespace css {
 
+  /// event number type
+  using evnum_t = unsigned long;
+
   /// exit code for general error
   int const EXIT_ERROR  = 1;
   /// exit code for syntax error

--- a/src/Tools.h
+++ b/src/Tools.h
@@ -4,7 +4,8 @@
 #include <functional>
 #include <sstream>
 
-namespace clas {
+/// namespace for `clas-stringspinner` (abbreviated as "css")
+namespace css {
 
   /// exit code for general error
   int const EXIT_ERROR  = 1;

--- a/src/Tools.h
+++ b/src/Tools.h
@@ -4,8 +4,8 @@
 #include <functional>
 #include <sstream>
 
-/// namespace for `clas-stringspinner` (abbreviated as "css")
-namespace css {
+/// namespace for `clas-stringspinner`
+namespace string_spinner {
 
   /// event number type
   using evnum_t = unsigned long;

--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -761,7 +761,7 @@ int main(int argc, char** argv)
 
     // stream to HIPO file
     if(save_hipo)
-      hipo_file->Stream(lund_header, lund_particles);
+      hipo_file->Stream(lund_header, lund_particles, evnum);
 
     // finalize
     num_events_saved++;

--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -2,7 +2,7 @@
 #include <stringspinner/StringSpinner.h>
 
 #include "CheckList.h"
-#include "Lund.h"
+#include "Hipo.h"
 
 //////////////////////////////////////////////////////////////////////////////////
 
@@ -24,7 +24,7 @@ enum obj_enum { objBeam, objTarget, nObj };
 std::string const obj_name[nObj] = { "beam", "target" };
 
 // default option values
-static clas::evnum_t            num_events               = 10000;
+static css::evnum_t             num_events               = 10000;
 static std::string              out_file_name            = "clas-stringspinner.dat";
 static int                      precision                = 5;
 static bool                     save_kin                 = false;
@@ -42,9 +42,9 @@ static bool                     enable_patch_boost       = false;
 static int                      cut_pion_multiplicity    = 0;
 
 // cut checklists
-clas::CheckList cut_inclusive{"cut-inclusive", clas::CheckList::kNoCuts};
-clas::CheckList cut_theta{"cut-theta", clas::CheckList::k1hCuts};
-clas::CheckList cut_z_2h{"cut-z-2h", clas::CheckList::k2hCuts};
+css::CheckList cut_inclusive{"cut-inclusive", css::CheckList::kNoCuts};
+css::CheckList cut_theta{"cut-theta", css::CheckList::k1hCuts};
+css::CheckList cut_z_2h{"cut-z-2h", css::CheckList::k2hCuts};
 
 //////////////////////////////////////////////////////////////////////////////////
 
@@ -283,7 +283,7 @@ int main(int argc, char** argv)
 
   if(argc <= 1) {
     Usage();
-    return clas::EXIT_SYNTAX;
+    return css::EXIT_SYNTAX;
   };
 
   char opt;
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
       case opt_set: config_overrides.push_back(std::string(optarg)); break;
       case opt_patch_boost: patch_boost = std::string(optarg); break;
       case opt_count_before_cuts: enable_count_before_cuts = true; break;
-      case opt_verbose: clas::enable_verbose_mode = true; break;
+      case opt_verbose: css::enable_verbose_mode = true; break;
       case opt_help:
         Usage();
         return 0;
@@ -316,19 +316,19 @@ int main(int argc, char** argv)
         fmt::println("{}", CLAS_STRINGSPINNER_VERSION);
         return 0;
       case '?':
-        return clas::EXIT_ERROR;
+        return css::EXIT_ERROR;
     }
   }
 
   // check if seed is too large; if so, % SEED_MAX
   if(seed > SEED_MAX) {
     auto new_seed = seed % SEED_MAX;
-    clas::Error("value of option '--seed' is too large for Pythia8: {} > {}; setting it to `seed % {}` = {}", seed, SEED_MAX, SEED_MAX, new_seed);
+    css::Error("value of option '--seed' is too large for Pythia8: {} > {}; setting it to `seed % {}` = {}", seed, SEED_MAX, SEED_MAX, new_seed);
     seed = new_seed;
   }
 
   // print options
-  if(clas::enable_verbose_mode) {
+  if(css::enable_verbose_mode) {
     fmt::println("{:=^82}", " Arguments ");
     fmt::println("{:>30} = {}", "num-events", num_events);
     fmt::println("{:>30} = {}", "count-before-cuts", enable_count_before_cuts ? "true" : "false");
@@ -366,8 +366,8 @@ int main(int argc, char** argv)
     apply_config_func = CONFIG_MAP.at(config_name);
   }
   catch(std::out_of_range const& ex) {
-    clas::Error("value of option '--config' is {:?}, which is not found", config_name);
-    return clas::EXIT_ERROR;
+    css::Error("value of option '--config' is {:?}, which is not found", config_name);
+    return css::EXIT_ERROR;
   }
 
   // set target PDG and mass
@@ -381,7 +381,7 @@ int main(int argc, char** argv)
     target_pdg        = 2112;
     target_atomic_num = 0;
   }
-  else return clas::Error("unknown '--target-type' value {:?}", target_type);
+  else return css::Error("unknown '--target-type' value {:?}", target_type);
   auto target_mass = pdt.constituentMass(target_pdg);
 
   // parse polarization type and spins -> set `spin_vec`, the spin vector for beam and target
@@ -390,7 +390,7 @@ int main(int argc, char** argv)
   bool obj_is_polarized[nObj] = { false, false };
   enum spin_vec_enum { eX, eY, eZ };
   if(pol_type.length() != 2)
-    return clas::Error("option '--pol-type' value {:?} is not 2 characters", pol_type);
+    return css::Error("option '--pol-type' value {:?} is not 2 characters", pol_type);
   for(int obj = 0; obj < nObj; obj++) {
 
     // parse polarization type
@@ -412,7 +412,7 @@ int main(int argc, char** argv)
         case 'L': pol_type_name = "longitudinal"; break;
         case 'T': pol_type_name = "transverse"; break;
         default:
-          return clas::Error("option '--pol-type' has unknown {} polarization type {:?}", obj_name[obj], pol_type.c_str()[obj]);
+          return css::Error("option '--pol-type' has unknown {} polarization type {:?}", obj_name[obj], pol_type.c_str()[obj]);
       }
 
       // use opposite sign for beam spin, since quark momentum reversed after hard scattering
@@ -420,9 +420,9 @@ int main(int argc, char** argv)
 
       // parse spin type
       if(spin_type[obj].empty())
-        return clas::Error("option '--{}Spin' must be set when {} polarization is {}", obj_name[obj], obj_name[obj], pol_type_name);
+        return css::Error("option '--{}Spin' must be set when {} polarization is {}", obj_name[obj], obj_name[obj], pol_type_name);
       if(spin_type[obj].length() > 1)
-        return clas::Error("option '--{}Spin' value {:?} is not 1 character", obj_name[obj], spin_type[obj]);
+        return css::Error("option '--{}Spin' value {:?} is not 1 character", obj_name[obj], spin_type[obj]);
       switch(std::tolower(spin_type[obj].c_str()[0])) {
         case 'p':
           {
@@ -452,11 +452,11 @@ int main(int argc, char** argv)
             break;
           }
         default:
-          return clas::Error("option '--{}Spin' has unknown value {:?}", obj_name[obj], spin_type[obj]);
+          return css::Error("option '--{}Spin' has unknown value {:?}", obj_name[obj], spin_type[obj]);
       }
     }
 
-    if(clas::enable_verbose_mode) {
+    if(css::enable_verbose_mode) {
       fmt::println("{:>30} = {}", fmt::format("{} polarization type", obj_name[obj]), pol_type_name);
       fmt::println("{:>30} = {}", fmt::format("{} spin", obj_name[obj]), spin_name);
       fmt::println("{:>30} = ({})", fmt::format("{} spin vector", obj == objBeam ? "quark" : obj_name[obj]), fmt::join(spin_vec[obj], ", "));
@@ -477,7 +477,7 @@ int main(int argc, char** argv)
   } else if(patch_boost == "none") {
     enable_patch_boost = false;
   } else {
-    return clas::Error("option '--patch-boost' has unknown value {:?}", patch_boost);
+    return css::Error("option '--patch-boost' has unknown value {:?}", patch_boost);
   }
 
   // configure pythia
@@ -487,9 +487,9 @@ int main(int argc, char** argv)
   //// read config file
   apply_config_func(pyth);
   //// set verbosity
-  set_config(pyth, fmt::format("Next:numberShowEvent = {}", clas::enable_verbose_mode ? 10*num_events : 0)); // more than `num_events` since we want to see effects of cuts
-  // set_config(pyth, fmt::format("Next:numberShowProcess = {}", clas::enable_verbose_mode ? 10*num_events : 0));
-  // set_config(pyth, fmt::format("Next:numberShowInfo = {}", clas::enable_verbose_mode ? 10*num_events : 0));
+  set_config(pyth, fmt::format("Next:numberShowEvent = {}", css::enable_verbose_mode ? 10*num_events : 0)); // more than `num_events` since we want to see effects of cuts
+  // set_config(pyth, fmt::format("Next:numberShowProcess = {}", css::enable_verbose_mode ? 10*num_events : 0));
+  // set_config(pyth, fmt::format("Next:numberShowInfo = {}", css::enable_verbose_mode ? 10*num_events : 0));
   //// beam and target types
   set_config(pyth, fmt::format("Beams:idA = {}", BEAM_PDG));
   set_config(pyth, fmt::format("Beams:idB = {}", target_pdg));
@@ -523,13 +523,13 @@ int main(int argc, char** argv)
     kin_file_dis = std::make_unique<fmt::ostream>(fmt::output_file(kin_file_dis_name, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC));
     kin_file_1h  = std::make_unique<fmt::ostream>(fmt::output_file(kin_file_1h_name, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC));
     kin_file_2h  = std::make_unique<fmt::ostream>(fmt::output_file(kin_file_2h_name, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC));
-    clas::InclusiveKin::Header(*kin_file_dis);
-    clas::SingleHadronKin::Header(*kin_file_1h);
-    clas::DihadronKin::Header(*kin_file_2h);
+    css::InclusiveKin::Header(*kin_file_dis);
+    css::SingleHadronKin::Header(*kin_file_1h);
+    css::DihadronKin::Header(*kin_file_2h);
   }
 
   // set `LundHeader` constant variables
-  clas::LundHeader lund_header{
+  css::LundHeader lund_header{
     .target_mass       = target_mass,
     .target_atomic_num = target_atomic_num,
     .target_spin       = spin_num[objTarget],
@@ -550,7 +550,7 @@ int main(int argc, char** argv)
     if(enable_count_before_cuts && num_events_generated >= num_events)
       break;
     auto evnum = enable_count_before_cuts ? num_events_generated : num_events_saved;
-    if(clas::enable_verbose_mode)
+    if(css::enable_verbose_mode)
       fmt::println("\n>>> EVENT {} ======================================================================", evnum);
     if(!pyth.next()) // generate the event
       continue;
@@ -566,15 +566,15 @@ int main(int argc, char** argv)
       auto const& par__proc = proc[patch_boost_particle_row]; // beam (or target) momentum in hard-process frame, which is assumed to be the lab frame
       // check that we are using the correct beam (or target) particle
       if(par__evt.status() != -12) {
-        clas::EventError("patch-boost particle is not an incoming beam (or target) particle");
+        css::EventError("patch-boost particle is not an incoming beam (or target) particle");
         continue;
       }
       if(par__evt.id() != patch_boost_particle_pdg) {
-        clas::EventError("patch-boost particle does not have the expected PDG: {} != {}", par__evt.id(), patch_boost_particle_pdg);
+        css::EventError("patch-boost particle does not have the expected PDG: {} != {}", par__evt.id(), patch_boost_particle_pdg);
         continue;
       }
       if(par__evt.id() != par__proc.id()) {
-        clas::EventError("patch-boost particle PDG mismatch between event record and hard-process record");
+        css::EventError("patch-boost particle PDG mismatch between event record and hard-process record");
         continue;
       }
       // perform the boost
@@ -590,7 +590,7 @@ int main(int argc, char** argv)
     //       );
     //   if(diff > 0.0001)
     //     EventError("mismatch of event-frame and hard-process-frame {} momentum; use '--verbose' for details', and consider changing the value of the '--patch-boost' option", name);
-    //   if(clas::enable_verbose_mode) {
+    //   if(css::enable_verbose_mode) {
     //     fmt::println("hard process {:<8} pz = {:<20.10}  E = {:<20.10}", name, proc[row].pz(), proc[row].e());
     //     fmt::println("event record {:<8} pz = {:<20.10}  E = {:<20.10}", name, evt[row].pz(),  evt[row].e());
     //   }
@@ -623,12 +623,12 @@ int main(int argc, char** argv)
       continue;
 
     // find scattered lepton (if needed)
-    clas::InclusiveKin inc_kin;
+    css::InclusiveKin inc_kin;
     std::optional<int> lepton_idx;
     if(cut_z_2h.Enabled() || save_kin) {
       lepton_idx = FindScatteredLepton(evt);
       if(!lepton_idx.has_value()) { // no scattered lepton -> skip event
-        if(clas::enable_verbose_mode) fmt::println("no scattered lepton found");
+        if(css::enable_verbose_mode) fmt::println("no scattered lepton found");
         continue;
       }
       // calculate inclusive kinematics (if needed)
@@ -648,7 +648,7 @@ int main(int argc, char** argv)
     }
 
     // pair dihadrons (if needed)
-    std::vector<clas::DihadronKin> dih_kin;
+    std::vector<css::DihadronKin> dih_kin;
     if(cut_z_2h.Enabled() || save_kin) {
       for(int a = 0; a < evt.size(); a++) {
         auto const& parA = evt.at(a);
@@ -670,7 +670,7 @@ int main(int argc, char** argv)
     // check dihadron kinematics
     if(cut_z_2h.Enabled() || save_kin) {
       // check z cuts
-      if(!cut_z_2h.Check(evt, dih_kin, clas::DihadronKin::GetZfunction(inc_kin)))
+      if(!cut_z_2h.Check(evt, dih_kin, css::DihadronKin::GetZfunction(inc_kin)))
         continue;
       // calculate kinematics for all dihadrons (if needed)
       if(save_kin) {
@@ -681,8 +681,8 @@ int main(int argc, char** argv)
     }
 
     // event passed all cuts -> write to output file(s)
-    std::vector<clas::LundParticle> lund_particles;
-    std::vector<clas::SingleHadronKin> had_kin;
+    std::vector<css::LundParticle> lund_particles;
+    std::vector<css::SingleHadronKin> had_kin;
     for(auto const& par : evt) {
 
       // skip the "system" particle

--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -28,6 +28,7 @@ static css::evnum_t             num_events               = 10000;
 static std::string              out_file_name            = "clas-stringspinner.dat";
 static int                      precision                = 5;
 static bool                     save_kin                 = false;
+static bool                     save_hipo                = false;
 static double                   beam_energy              = 10.60410;
 static double                   target_beam_energy       = 0;
 static std::string              target_type              = "proton";
@@ -81,6 +82,8 @@ OUTPUT FILE CONTROL:
   --save-kin                       if set, save additional kinematics to text files
                                    - parsable by ROOT's TTree::ReadFile
                                    - cuts may be applied, e.g. save only pions (see code)
+
+  --save-hipo                      if set, save additional HIPO file
 
 
 BEAM AND TARGET PROPERTIES:
@@ -233,6 +236,7 @@ int main(int argc, char** argv)
     opt_out_file_name,
     opt_precision,
     opt_save_kin,
+    opt_save_hipo,
     opt_beam_energy,
     opt_target_beam_energy,
     opt_target_type,
@@ -259,6 +263,7 @@ int main(int argc, char** argv)
     {"out-file",              required_argument, nullptr, opt_out_file_name},
     {"precision",             required_argument, nullptr, opt_precision},
     {"save-kin",              no_argument,       nullptr, opt_save_kin},
+    {"save-hipo",             no_argument,       nullptr, opt_save_hipo},
     {"beam-energy",           required_argument, nullptr, opt_beam_energy},
     {"ebeam",                 required_argument, nullptr, opt_beam_energy},
     {"target-beam-energy",    required_argument, nullptr, opt_target_beam_energy},
@@ -293,6 +298,7 @@ int main(int argc, char** argv)
       case opt_out_file_name: out_file_name = std::string(optarg); break;
       case opt_precision: precision = std::stoi(optarg); break;
       case opt_save_kin: save_kin = true; break;
+      case opt_save_hipo: save_hipo = true; break;
       case opt_beam_energy: beam_energy = std::stod(optarg); break;
       case opt_target_beam_energy: target_beam_energy = std::stod(optarg); break;
       case opt_target_type: target_type = std::string(optarg); break;
@@ -519,6 +525,8 @@ int main(int argc, char** argv)
   std::string kin_file_dis_name = out_file_name + ".dis.table";
   std::string kin_file_1h_name  = out_file_name + ".1h.table";
   std::string kin_file_2h_name  = out_file_name + ".2h.table";
+  std::unique_ptr<css::Hipo> hipo_file;
+  std::string hipo_file_name = out_file_name + ".hipo";
   if(save_kin) {
     kin_file_dis = std::make_unique<fmt::ostream>(fmt::output_file(kin_file_dis_name, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC));
     kin_file_1h  = std::make_unique<fmt::ostream>(fmt::output_file(kin_file_1h_name, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC));
@@ -527,6 +535,8 @@ int main(int argc, char** argv)
     css::SingleHadronKin::Header(*kin_file_1h);
     css::DihadronKin::Header(*kin_file_2h);
   }
+  if(save_hipo)
+    hipo_file = std::make_unique<css::Hipo>(hipo_file_name);
 
   // set `LundHeader` constant variables
   css::LundHeader lund_header{
@@ -749,6 +759,10 @@ int main(int argc, char** argv)
       }
     }
 
+    // stream to HIPO file
+    if(save_hipo)
+      hipo_file->Stream(lund_header, lund_particles);
+
     // finalize
     num_events_saved++;
     if(num_events_saved % 1000 == 0)
@@ -757,6 +771,10 @@ int main(int argc, char** argv)
       break;
 
   } // end EVENT LOOP
+
+  // close output files
+  if(save_hipo)
+    hipo_file->Close();
 
   // print info
   fmt::println("\nGENERATED LUND FILE: {}", out_file_name);

--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -777,10 +777,12 @@ int main(int argc, char** argv)
     hipo_file->Close();
 
   // print info
-  fmt::println("\nGENERATED LUND FILE: {}", out_file_name);
+  fmt::println("{:=^50}", " DONE ");
+  fmt::println("PRODUCED LUND FILE: {}", out_file_name);
+  if(save_hipo)
+    fmt::println("PRODUCED HIPO FILE: {}", hipo_file_name);
   if(save_kin) {
-    fmt::print(fmt::runtime(R"(
-KINEMATICS FILES:
+    fmt::print(fmt::runtime(R"(PRODUCED KINEMATICS FILES:
   inclusive:      {}
   single-hadrons: {}
   dihadrons:      {})" + std::string("\n")),
@@ -789,8 +791,7 @@ KINEMATICS FILES:
         kin_file_2h_name
         );
   }
-  fmt::print(fmt::runtime(R"(
-NUMBER OF EVENTS:
+  fmt::print(fmt::runtime(R"(NUMBER OF EVENTS:
   saved:          {}
   generated:      {}
   fraction saved: {:.3g} %)" + std::string("\n")),

--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -15,16 +15,16 @@ static std::map<std::string, std::function<void(Pythia8::Pythia&)>> CONFIG_MAP =
 //////////////////////////////////////////////////////////////////////////////////
 
 // constants
-int const SEED_MAX    = 900000000;
-int const BEAM_PDG    = 11;
-int const BEAM_ROW    = 1;
-int const TARGET_ROW  = 2;
+int const SEED_MAX   = 900000000;
+int const BEAM_PDG   = 11;
+int const BEAM_ROW   = 1;
+int const TARGET_ROW = 2;
 
 enum obj_enum { objBeam, objTarget, nObj };
 std::string const obj_name[nObj] = { "beam", "target" };
 
 // default option values
-static css::evnum_t             num_events               = 10000;
+static string_spinner::evnum_t  num_events               = 10000;
 static std::string              out_file_name            = "clas-stringspinner.dat";
 static int                      precision                = 5;
 static bool                     save_kin                 = false;
@@ -43,9 +43,9 @@ static bool                     enable_patch_boost       = false;
 static int                      cut_pion_multiplicity    = 0;
 
 // cut checklists
-css::CheckList cut_inclusive{"cut-inclusive", css::CheckList::kNoCuts};
-css::CheckList cut_theta{"cut-theta", css::CheckList::k1hCuts};
-css::CheckList cut_z_2h{"cut-z-2h", css::CheckList::k2hCuts};
+string_spinner::CheckList cut_inclusive{"cut-inclusive", string_spinner::CheckList::kNoCuts};
+string_spinner::CheckList cut_theta{"cut-theta", string_spinner::CheckList::k1hCuts};
+string_spinner::CheckList cut_z_2h{"cut-z-2h", string_spinner::CheckList::k2hCuts};
 
 //////////////////////////////////////////////////////////////////////////////////
 
@@ -288,7 +288,7 @@ int main(int argc, char** argv)
 
   if(argc <= 1) {
     Usage();
-    return css::EXIT_SYNTAX;
+    return string_spinner::EXIT_SYNTAX;
   };
 
   char opt;
@@ -314,7 +314,7 @@ int main(int argc, char** argv)
       case opt_set: config_overrides.push_back(std::string(optarg)); break;
       case opt_patch_boost: patch_boost = std::string(optarg); break;
       case opt_count_before_cuts: enable_count_before_cuts = true; break;
-      case opt_verbose: css::enable_verbose_mode = true; break;
+      case opt_verbose: string_spinner::enable_verbose_mode = true; break;
       case opt_help:
         Usage();
         return 0;
@@ -322,19 +322,19 @@ int main(int argc, char** argv)
         fmt::println("{}", CLAS_STRINGSPINNER_VERSION);
         return 0;
       case '?':
-        return css::EXIT_ERROR;
+        return string_spinner::EXIT_ERROR;
     }
   }
 
   // check if seed is too large; if so, % SEED_MAX
   if(seed > SEED_MAX) {
     auto new_seed = seed % SEED_MAX;
-    css::Error("value of option '--seed' is too large for Pythia8: {} > {}; setting it to `seed % {}` = {}", seed, SEED_MAX, SEED_MAX, new_seed);
+    string_spinner::Error("value of option '--seed' is too large for Pythia8: {} > {}; setting it to `seed % {}` = {}", seed, SEED_MAX, SEED_MAX, new_seed);
     seed = new_seed;
   }
 
   // print options
-  if(css::enable_verbose_mode) {
+  if(string_spinner::enable_verbose_mode) {
     fmt::println("{:=^82}", " Arguments ");
     fmt::println("{:>30} = {}", "num-events", num_events);
     fmt::println("{:>30} = {}", "count-before-cuts", enable_count_before_cuts ? "true" : "false");
@@ -372,8 +372,8 @@ int main(int argc, char** argv)
     apply_config_func = CONFIG_MAP.at(config_name);
   }
   catch(std::out_of_range const& ex) {
-    css::Error("value of option '--config' is {:?}, which is not found", config_name);
-    return css::EXIT_ERROR;
+    string_spinner::Error("value of option '--config' is {:?}, which is not found", config_name);
+    return string_spinner::EXIT_ERROR;
   }
 
   // set target PDG and mass
@@ -387,7 +387,7 @@ int main(int argc, char** argv)
     target_pdg        = 2112;
     target_atomic_num = 0;
   }
-  else return css::Error("unknown '--target-type' value {:?}", target_type);
+  else return string_spinner::Error("unknown '--target-type' value {:?}", target_type);
   auto target_mass = pdt.constituentMass(target_pdg);
 
   // parse polarization type and spins -> set `spin_vec`, the spin vector for beam and target
@@ -396,7 +396,7 @@ int main(int argc, char** argv)
   bool obj_is_polarized[nObj] = { false, false };
   enum spin_vec_enum { eX, eY, eZ };
   if(pol_type.length() != 2)
-    return css::Error("option '--pol-type' value {:?} is not 2 characters", pol_type);
+    return string_spinner::Error("option '--pol-type' value {:?} is not 2 characters", pol_type);
   for(int obj = 0; obj < nObj; obj++) {
 
     // parse polarization type
@@ -418,7 +418,7 @@ int main(int argc, char** argv)
         case 'L': pol_type_name = "longitudinal"; break;
         case 'T': pol_type_name = "transverse"; break;
         default:
-          return css::Error("option '--pol-type' has unknown {} polarization type {:?}", obj_name[obj], pol_type.c_str()[obj]);
+          return string_spinner::Error("option '--pol-type' has unknown {} polarization type {:?}", obj_name[obj], pol_type.c_str()[obj]);
       }
 
       // use opposite sign for beam spin, since quark momentum reversed after hard scattering
@@ -426,9 +426,9 @@ int main(int argc, char** argv)
 
       // parse spin type
       if(spin_type[obj].empty())
-        return css::Error("option '--{}Spin' must be set when {} polarization is {}", obj_name[obj], obj_name[obj], pol_type_name);
+        return string_spinner::Error("option '--{}Spin' must be set when {} polarization is {}", obj_name[obj], obj_name[obj], pol_type_name);
       if(spin_type[obj].length() > 1)
-        return css::Error("option '--{}Spin' value {:?} is not 1 character", obj_name[obj], spin_type[obj]);
+        return string_spinner::Error("option '--{}Spin' value {:?} is not 1 character", obj_name[obj], spin_type[obj]);
       switch(std::tolower(spin_type[obj].c_str()[0])) {
         case 'p':
           {
@@ -458,11 +458,11 @@ int main(int argc, char** argv)
             break;
           }
         default:
-          return css::Error("option '--{}Spin' has unknown value {:?}", obj_name[obj], spin_type[obj]);
+          return string_spinner::Error("option '--{}Spin' has unknown value {:?}", obj_name[obj], spin_type[obj]);
       }
     }
 
-    if(css::enable_verbose_mode) {
+    if(string_spinner::enable_verbose_mode) {
       fmt::println("{:>30} = {}", fmt::format("{} polarization type", obj_name[obj]), pol_type_name);
       fmt::println("{:>30} = {}", fmt::format("{} spin", obj_name[obj]), spin_name);
       fmt::println("{:>30} = ({})", fmt::format("{} spin vector", obj == objBeam ? "quark" : obj_name[obj]), fmt::join(spin_vec[obj], ", "));
@@ -483,7 +483,7 @@ int main(int argc, char** argv)
   } else if(patch_boost == "none") {
     enable_patch_boost = false;
   } else {
-    return css::Error("option '--patch-boost' has unknown value {:?}", patch_boost);
+    return string_spinner::Error("option '--patch-boost' has unknown value {:?}", patch_boost);
   }
 
   // configure pythia
@@ -493,9 +493,9 @@ int main(int argc, char** argv)
   //// read config file
   apply_config_func(pyth);
   //// set verbosity
-  set_config(pyth, fmt::format("Next:numberShowEvent = {}", css::enable_verbose_mode ? 10*num_events : 0)); // more than `num_events` since we want to see effects of cuts
-  // set_config(pyth, fmt::format("Next:numberShowProcess = {}", css::enable_verbose_mode ? 10*num_events : 0));
-  // set_config(pyth, fmt::format("Next:numberShowInfo = {}", css::enable_verbose_mode ? 10*num_events : 0));
+  set_config(pyth, fmt::format("Next:numberShowEvent = {}", string_spinner::enable_verbose_mode ? 10*num_events : 0)); // more than `num_events` since we want to see effects of cuts
+  // set_config(pyth, fmt::format("Next:numberShowProcess = {}", string_spinner::enable_verbose_mode ? 10*num_events : 0));
+  // set_config(pyth, fmt::format("Next:numberShowInfo = {}", string_spinner::enable_verbose_mode ? 10*num_events : 0));
   //// beam and target types
   set_config(pyth, fmt::format("Beams:idA = {}", BEAM_PDG));
   set_config(pyth, fmt::format("Beams:idB = {}", target_pdg));
@@ -525,21 +525,21 @@ int main(int argc, char** argv)
   std::string kin_file_dis_name = out_file_name + ".dis.table";
   std::string kin_file_1h_name  = out_file_name + ".1h.table";
   std::string kin_file_2h_name  = out_file_name + ".2h.table";
-  std::unique_ptr<css::Hipo> hipo_file;
+  std::unique_ptr<string_spinner::Hipo> hipo_file;
   std::string hipo_file_name = out_file_name + ".hipo";
   if(save_kin) {
     kin_file_dis = std::make_unique<fmt::ostream>(fmt::output_file(kin_file_dis_name, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC));
     kin_file_1h  = std::make_unique<fmt::ostream>(fmt::output_file(kin_file_1h_name, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC));
     kin_file_2h  = std::make_unique<fmt::ostream>(fmt::output_file(kin_file_2h_name, fmt::file::WRONLY | fmt::file::CREATE | fmt::file::TRUNC));
-    css::InclusiveKin::Header(*kin_file_dis);
-    css::SingleHadronKin::Header(*kin_file_1h);
-    css::DihadronKin::Header(*kin_file_2h);
+    string_spinner::InclusiveKin::Header(*kin_file_dis);
+    string_spinner::SingleHadronKin::Header(*kin_file_1h);
+    string_spinner::DihadronKin::Header(*kin_file_2h);
   }
   if(save_hipo)
-    hipo_file = std::make_unique<css::Hipo>(hipo_file_name);
+    hipo_file = std::make_unique<string_spinner::Hipo>(hipo_file_name);
 
   // set `LundHeader` constant variables
-  css::LundHeader lund_header{
+  string_spinner::LundHeader lund_header{
     .target_mass       = target_mass,
     .target_atomic_num = target_atomic_num,
     .target_spin       = spin_num[objTarget],
@@ -560,7 +560,7 @@ int main(int argc, char** argv)
     if(enable_count_before_cuts && num_events_generated >= num_events)
       break;
     auto evnum = enable_count_before_cuts ? num_events_generated : num_events_saved;
-    if(css::enable_verbose_mode)
+    if(string_spinner::enable_verbose_mode)
       fmt::println("\n>>> EVENT {} ======================================================================", evnum);
     if(!pyth.next()) // generate the event
       continue;
@@ -576,15 +576,15 @@ int main(int argc, char** argv)
       auto const& par__proc = proc[patch_boost_particle_row]; // beam (or target) momentum in hard-process frame, which is assumed to be the lab frame
       // check that we are using the correct beam (or target) particle
       if(par__evt.status() != -12) {
-        css::EventError("patch-boost particle is not an incoming beam (or target) particle");
+        string_spinner::EventError("patch-boost particle is not an incoming beam (or target) particle");
         continue;
       }
       if(par__evt.id() != patch_boost_particle_pdg) {
-        css::EventError("patch-boost particle does not have the expected PDG: {} != {}", par__evt.id(), patch_boost_particle_pdg);
+        string_spinner::EventError("patch-boost particle does not have the expected PDG: {} != {}", par__evt.id(), patch_boost_particle_pdg);
         continue;
       }
       if(par__evt.id() != par__proc.id()) {
-        css::EventError("patch-boost particle PDG mismatch between event record and hard-process record");
+        string_spinner::EventError("patch-boost particle PDG mismatch between event record and hard-process record");
         continue;
       }
       // perform the boost
@@ -600,7 +600,7 @@ int main(int argc, char** argv)
     //       );
     //   if(diff > 0.0001)
     //     EventError("mismatch of event-frame and hard-process-frame {} momentum; use '--verbose' for details', and consider changing the value of the '--patch-boost' option", name);
-    //   if(css::enable_verbose_mode) {
+    //   if(string_spinner::enable_verbose_mode) {
     //     fmt::println("hard process {:<8} pz = {:<20.10}  E = {:<20.10}", name, proc[row].pz(), proc[row].e());
     //     fmt::println("event record {:<8} pz = {:<20.10}  E = {:<20.10}", name, evt[row].pz(),  evt[row].e());
     //   }
@@ -633,12 +633,12 @@ int main(int argc, char** argv)
       continue;
 
     // find scattered lepton (if needed)
-    css::InclusiveKin inc_kin;
+    string_spinner::InclusiveKin inc_kin;
     std::optional<int> lepton_idx;
     if(cut_z_2h.Enabled() || save_kin) {
       lepton_idx = FindScatteredLepton(evt);
       if(!lepton_idx.has_value()) { // no scattered lepton -> skip event
-        if(css::enable_verbose_mode) fmt::println("no scattered lepton found");
+        if(string_spinner::enable_verbose_mode) fmt::println("no scattered lepton found");
         continue;
       }
       // calculate inclusive kinematics (if needed)
@@ -658,7 +658,7 @@ int main(int argc, char** argv)
     }
 
     // pair dihadrons (if needed)
-    std::vector<css::DihadronKin> dih_kin;
+    std::vector<string_spinner::DihadronKin> dih_kin;
     if(cut_z_2h.Enabled() || save_kin) {
       for(int a = 0; a < evt.size(); a++) {
         auto const& parA = evt.at(a);
@@ -680,7 +680,7 @@ int main(int argc, char** argv)
     // check dihadron kinematics
     if(cut_z_2h.Enabled() || save_kin) {
       // check z cuts
-      if(!cut_z_2h.Check(evt, dih_kin, css::DihadronKin::GetZfunction(inc_kin)))
+      if(!cut_z_2h.Check(evt, dih_kin, string_spinner::DihadronKin::GetZfunction(inc_kin)))
         continue;
       // calculate kinematics for all dihadrons (if needed)
       if(save_kin) {
@@ -691,8 +691,8 @@ int main(int argc, char** argv)
     }
 
     // event passed all cuts -> write to output file(s)
-    std::vector<css::LundParticle> lund_particles;
-    std::vector<css::SingleHadronKin> had_kin;
+    std::vector<string_spinner::LundParticle> lund_particles;
+    std::vector<string_spinner::SingleHadronKin> had_kin;
     for(auto const& par : evt) {
 
       // skip the "system" particle

--- a/src/clas-stringspinner.cpp
+++ b/src/clas-stringspinner.cpp
@@ -378,14 +378,17 @@ int main(int argc, char** argv)
 
   // set target PDG and mass
   int target_pdg;
-  int target_atomic_num;
+  int target_atomic_num; // Z, the number of protons
+  int target_mass_num;   // A, the number of protons + neutrons
   if(target_type == "proton") {
     target_pdg        = 2212;
     target_atomic_num = 1;
+    target_mass_num   = 1;
   }
   else if(target_type == "neutron") {
     target_pdg        = 2112;
     target_atomic_num = 0;
+    target_mass_num   = 1;
   }
   else return string_spinner::Error("unknown '--target-type' value {:?}", target_type);
   auto target_mass = pdt.constituentMass(target_pdg);
@@ -542,6 +545,7 @@ int main(int argc, char** argv)
   string_spinner::LundHeader lund_header{
     .target_mass       = target_mass,
     .target_atomic_num = target_atomic_num,
+    .target_mass_num   = target_mass_num,
     .target_spin       = spin_num[objTarget],
     .beam_spin         = spin_num[objBeam],
     .beam_type         = BEAM_PDG,


### PR DESCRIPTION
For convenience with downstream generator-level analysis code, output a HIPO file with banks including `MC::Particle` and `MC::Lund`.

`hipo-cpp` is an optional dependency, therefore HIPO output will only be supported if `hipo-cpp` is found at build time.

Also, namespace `clas` is changed to `string_spinner`, to be more specific to this project.